### PR TITLE
[READY] Implement Sortable where possible

### DIFF
--- a/src/Api/KeyValueStore.php
+++ b/src/Api/KeyValueStore.php
@@ -265,6 +265,7 @@ interface KeyValueStore
      * }
      * ```
      *
+     *
      * @throws WriteException If the store cannot be written.
      */
     public function clear();

--- a/src/Api/SortableStore.php
+++ b/src/Api/SortableStore.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the webmozart/key-value-store package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\KeyValueStore\Api;
+
+/**
+ * A sortable key-value store.
+ *
+ * In addition of the properties of a classical store, a sortable store
+ * has the ability to sort its values by its keys.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+interface SortableStore extends KeyValueStore
+{
+    /**
+     * Sort the store by its keys.
+     *
+     * The store values will be arranged from lowest to highest when this
+     * function has completed.
+     *
+     * This method accepts an optional second parameter that may be used
+     * to modify the sorting behavior using the standard sort flags of PHP.
+     *
+     * @see http://php.net/manual/en/function.sort.php
+     *
+     * @param int $flags Sorting type flags (from the standard PHP sort flags).
+     *
+     * @throws ReadException  If the store cannot be read.
+     * @throws WriteException If the store cannot be written.
+     */
+    public function sort($flags = SORT_REGULAR);
+}

--- a/src/ArrayStore.php
+++ b/src/ArrayStore.php
@@ -11,8 +11,8 @@
 
 namespace Webmozart\KeyValueStore;
 
-use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
+use Webmozart\KeyValueStore\Api\SortableStore;
 use Webmozart\KeyValueStore\Util\KeyUtil;
 
 /**
@@ -24,7 +24,7 @@ use Webmozart\KeyValueStore\Util\KeyUtil;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ArrayStore implements KeyValueStore
+class ArrayStore implements SortableStore
 {
     /**
      * @var array
@@ -161,5 +161,13 @@ class ArrayStore implements KeyValueStore
     public function toArray()
     {
         return $this->array;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sort($flags = SORT_REGULAR)
+    {
+        ksort($this->array, $flags);
     }
 }

--- a/src/CachingDecorator.php
+++ b/src/CachingDecorator.php
@@ -19,13 +19,13 @@ use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 
 /**
- * A key-value store replicated in a cache.
+ * A caching decorator implementing a cache layer for any store.
  *
  * @since  1.0
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CachedStore implements KeyValueStore
+class CachingDecorator implements KeyValueStore
 {
     /**
      * @var KeyValueStore
@@ -46,6 +46,8 @@ class CachedStore implements KeyValueStore
      * @param Cache         $cache The cache.
      * @param int           $ttl   The time-to-live for cache entries. If set to
      *                             0, cache entries never expire.
+     *
+     * @throws InvalidArgumentException If the provided cache is not supported
      */
     public function __construct(KeyValueStore $store, Cache $cache, $ttl = 0)
     {

--- a/src/JsonFileStore.php
+++ b/src/JsonFileStore.php
@@ -13,9 +13,9 @@ namespace Webmozart\KeyValueStore;
 
 use stdClass;
 use Webmozart\Assert\Assert;
-use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 use Webmozart\KeyValueStore\Api\ReadException;
+use Webmozart\KeyValueStore\Api\SortableStore;
 use Webmozart\KeyValueStore\Api\UnsupportedValueException;
 use Webmozart\KeyValueStore\Api\WriteException;
 use Webmozart\KeyValueStore\Util\KeyUtil;
@@ -28,7 +28,7 @@ use Webmozart\KeyValueStore\Util\Serializer;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class JsonFileStore implements KeyValueStore
+class JsonFileStore implements SortableStore
 {
     /**
      * This seems to be the biggest float supported by json_encode()/json_decode().
@@ -210,6 +210,18 @@ class JsonFileStore implements KeyValueStore
     public function keys()
     {
         return array_keys($this->load());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sort($flags = SORT_REGULAR)
+    {
+        $data = $this->load();
+
+        ksort($data, $flags);
+
+        $this->save($data);
     }
 
     private function load()

--- a/tests/AbstractKeyValueStoreTest.php
+++ b/tests/AbstractKeyValueStoreTest.php
@@ -13,6 +13,7 @@ namespace Webmozart\KeyValueStore\Tests;
 
 use PHPUnit_Framework_TestCase;
 use Webmozart\KeyValueStore\Api\KeyValueStore;
+use Webmozart\KeyValueStore\Api\SortableStore;
 use Webmozart\KeyValueStore\Tests\Fixtures\NotSerializable;
 use Webmozart\KeyValueStore\Tests\Fixtures\PrivateProperties;
 
@@ -26,12 +27,12 @@ abstract class AbstractKeyValueStoreTest extends PHPUnit_Framework_TestCase
     const BINARY_INPUT = "\xff\xf0";
 
     /**
-     * @var KeyValueStore
+     * @var KeyValueStore|SortableStore
      */
-    private $store;
+    protected $store;
 
     /**
-     * @return KeyValueStore The created store.
+     * @return KeyValueStore|SortableStore The created store.
      */
     abstract protected function createStore();
 

--- a/tests/AbstractSortableStoreTest.php
+++ b/tests/AbstractSortableStoreTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the webmozart/key-value-store package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\KeyValueStore\Tests;
+
+/**
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractSortableStoreTest extends AbstractKeyValueStoreTest
+{
+    /**
+     * @expectedException \Webmozart\KeyValueStore\Api\ReadException
+     */
+    abstract public function testSortThrowsReadExceptionIfReadFails();
+
+    /**
+     * @expectedException \Webmozart\KeyValueStore\Api\WriteException
+     */
+    abstract public function testSortThrowsWriteExceptionIfWriteFails();
+
+    public function testSortRegularStringKeys()
+    {
+        $this->store->set('c', 1);
+        $this->store->set('a', 2);
+        $this->store->set('b', 3);
+
+        $this->store->sort();
+
+        $this->assertSame(array(
+            'a' => 2,
+            'b' => 3,
+            'c' => 1,
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortRegularIntegerKeys()
+    {
+        $this->store->set(3, 'a');
+        $this->store->set(1, 'b');
+        $this->store->set(2, 'c');
+
+        $this->store->sort();
+
+        $this->assertSame(array(
+            1 => 'b',
+            2 => 'c',
+            3 => 'a',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortStringStringKeys()
+    {
+        $this->store->set('c', 1);
+        $this->store->set('a', 2);
+        $this->store->set('b', 3);
+
+        $this->store->sort(SORT_STRING);
+
+        $this->assertSame(array(
+            'a' => 2,
+            'b' => 3,
+            'c' => 1,
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortNumericIntegerKeys()
+    {
+        $this->store->set(3, 'a');
+        $this->store->set(1, 'b');
+        $this->store->set(2, 'c');
+
+        $this->store->sort(SORT_NUMERIC);
+
+        $this->assertSame(array(
+            1 => 'b',
+            2 => 'c',
+            3 => 'a',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortNaturalStringKeys()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('SORT_NATURAL not available');
+        }
+
+        $this->store->set('10', 'c');
+        $this->store->set('1', 'g');
+        $this->store->set('100', 'a');
+        $this->store->set('9', 'b');
+        $this->store->set('7a', 'h');
+        $this->store->set('7b', 'd');
+        $this->store->set('_5', 'z');
+
+        $this->store->sort(SORT_NATURAL);
+
+        $this->assertSame(array(
+            '1' => 'g',
+            '7a' => 'h',
+            '7b' => 'd',
+            '9' => 'b',
+            '10' => 'c',
+            '100' => 'a',
+            '_5' => 'z',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortCaseInsensitiveStringKeys()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('SORT_FLAG_CASE not available');
+        }
+
+        $this->store->set('_Ac', 'A');
+        $this->store->set('abc', 'F');
+        $this->store->set('_ab', 'G');
+        $this->store->set('ABB', 'E');
+        $this->store->set('Bce', 'C');
+        $this->store->set('bcd', 'D');
+        $this->store->set('bCf', 'E');
+
+        $this->store->sort(SORT_STRING | SORT_FLAG_CASE);
+
+        $this->assertSame(array(
+            '_ab' => 'G',
+            '_Ac' => 'A',
+            'ABB' => 'E',
+            'abc' => 'F',
+            'bcd' => 'D',
+            'Bce' => 'C',
+            'bCf' => 'E',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+}

--- a/tests/ArrayStoreTest.php
+++ b/tests/ArrayStoreTest.php
@@ -18,7 +18,7 @@ use Webmozart\KeyValueStore\ArrayStore;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ArrayStoreTest extends AbstractKeyValueStoreTest
+class ArrayStoreTest extends AbstractSortableStoreTest
 {
     protected function createStore()
     {
@@ -109,6 +109,18 @@ class ArrayStoreTest extends AbstractKeyValueStoreTest
     public function testKeysThrowsReadExceptionIfReadFails()
     {
         // ArrayStore never reads a storage
+        $this->assertTrue(true);
+    }
+
+    public function testSortThrowsReadExceptionIfReadFails()
+    {
+        // ArrayStore never reads a storage
+        $this->assertTrue(true);
+    }
+
+    public function testSortThrowsWriteExceptionIfWriteFails()
+    {
+        // ArrayStore never write a storage
         $this->assertTrue(true);
     }
 }

--- a/tests/CachingDecoratorTest.php
+++ b/tests/CachingDecoratorTest.php
@@ -19,14 +19,14 @@ use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 use Webmozart\KeyValueStore\Api\SerializationFailedException;
 use Webmozart\KeyValueStore\Api\WriteException;
-use Webmozart\KeyValueStore\CachedStore;
+use Webmozart\KeyValueStore\CachingDecorator;
 
 /**
  * @since  1.0
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CachedStoreTest extends PHPUnit_Framework_TestCase
+class CachingDecoratorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var PHPUnit_Framework_MockObject_MockObject|KeyValueStore
@@ -39,7 +39,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     private $cache;
 
     /**
-     * @var CachedStore
+     * @var CachingDecorator
      */
     private $store;
 
@@ -47,7 +47,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     {
         $this->innerStore = $this->getMock('Webmozart\KeyValueStore\Api\KeyValueStore');
         $this->cache = $this->getMock(__NAMESPACE__.'\Fixtures\TestClearableCache');
-        $this->store = new CachedStore($this->innerStore, $this->cache);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache);
     }
 
     /**
@@ -57,7 +57,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     {
         $this->cache = $this->getMock('Doctrine\Common\Cache\Cache');
 
-        new CachedStore($this->innerStore, $this->cache);
+        new CachingDecorator($this->innerStore, $this->cache);
     }
 
     public function testSetWritesToCache()
@@ -75,7 +75,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
 
     public function testSetWritesTtlIfGiven()
     {
-        $this->store = new CachedStore($this->innerStore, $this->cache, 100);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache, 100);
 
         $this->innerStore->expects($this->once())
             ->method('set')
@@ -143,7 +143,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
 
     public function testGetWritesTtlIfNotCached()
     {
-        $this->store = new CachedStore($this->innerStore, $this->cache, 100);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache, 100);
 
         $this->cache->expects($this->at(0))
             ->method('contains')
@@ -218,7 +218,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
 
     public function testGetOrFailWritesTtlIfNotCached()
     {
-        $this->store = new CachedStore($this->innerStore, $this->cache, 100);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache, 100);
 
         $this->cache->expects($this->at(0))
             ->method('contains')
@@ -406,7 +406,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     public function testClearDeletesAllFromCache()
     {
         $this->cache = $this->getMock(__NAMESPACE__.'\Fixtures\TestClearableCache');
-        $this->store = new CachedStore($this->innerStore, $this->cache);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache);
 
         $this->innerStore->expects($this->once())
             ->method('clear');
@@ -423,7 +423,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     public function testClearDoesNotDeleteAllFromCacheIfClearFails()
     {
         $this->cache = $this->getMock(__NAMESPACE__.'\Fixtures\TestClearableCache');
-        $this->store = new CachedStore($this->innerStore, $this->cache);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache);
 
         $this->innerStore->expects($this->once())
             ->method('clear')
@@ -438,7 +438,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     public function testClearFlushesCache()
     {
         $this->cache = $this->getMock(__NAMESPACE__.'\Fixtures\TestFlushableCache');
-        $this->store = new CachedStore($this->innerStore, $this->cache);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache);
 
         $this->innerStore->expects($this->once())
             ->method('clear');
@@ -452,7 +452,7 @@ class CachedStoreTest extends PHPUnit_Framework_TestCase
     public function testClearDeletesAllIfFlushableAndClearable()
     {
         $this->cache = $this->getMock(__NAMESPACE__.'\Fixtures\TestClearableFlushableCache');
-        $this->store = new CachedStore($this->innerStore, $this->cache);
+        $this->store = new CachingDecorator($this->innerStore, $this->cache);
 
         $this->innerStore->expects($this->once())
             ->method('clear');

--- a/tests/JsonFileStoreTest.php
+++ b/tests/JsonFileStoreTest.php
@@ -19,7 +19,7 @@ use Webmozart\KeyValueStore\JsonFileStore;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class JsonFileStoreTest extends AbstractKeyValueStoreTest
+class JsonFileStoreTest extends AbstractSortableStoreTest
 {
     private $tempDir;
 
@@ -283,5 +283,29 @@ class JsonFileStoreTest extends AbstractKeyValueStoreTest
 
         chmod($notReadable, 0000);
         $store->keys();
+    }
+
+    /**
+     * @expectedException \Webmozart\KeyValueStore\Api\ReadException
+     */
+    public function testSortThrowsReadExceptionIfReadFails()
+    {
+        touch($notReadable = $this->tempDir.'/not-readable.json');
+        $store = new JsonFileStore($notReadable);
+
+        chmod($notReadable, 0000);
+        $store->sort();
+    }
+
+    /**
+     * @expectedException \Webmozart\KeyValueStore\Api\WriteException
+     */
+    public function testSortThrowsWriteExceptionIfWriteFails()
+    {
+        touch($readOnlyFile = $this->tempDir.'/read-only.json');
+        $store = new JsonFileStore($readOnlyFile);
+
+        chmod($readOnlyFile, 0400);
+        $store->sort();
     }
 }

--- a/tests/NullStoreTest.php
+++ b/tests/NullStoreTest.php
@@ -92,4 +92,26 @@ class NullStoreTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(array(), $store->keys());
     }
+
+    public function testClearDoesNothing()
+    {
+        $store = new NullStore();
+
+        $store->set('foo1', 'bar1');
+        $store->set('foo2', 'bar2');
+        $store->clear();
+
+        $this->assertSame(array(), $store->keys());
+    }
+
+    public function testSortDoesNothing()
+    {
+        $store = new NullStore();
+
+        $store->set('foo1', 'bar1');
+        $store->set('foo2', 'bar2');
+        $store->sort();
+
+        $this->assertSame(array(), $store->keys());
+    }
 }

--- a/tests/SortableDecoratorTest.php
+++ b/tests/SortableDecoratorTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the webmozart/key-value-store package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\KeyValueStore\Tests;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use Webmozart\KeyValueStore\Api\KeyValueStore;
+use Webmozart\KeyValueStore\ArrayStore;
+use Webmozart\KeyValueStore\SortableDecorator;
+
+/**
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class SortableDecoratorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject|KeyValueStore
+     */
+    private $innerStore;
+
+    /**
+     * @var SortableDecorator
+     */
+    private $store;
+
+    protected function setUp()
+    {
+        $this->innerStore = $this->getMock('Webmozart\KeyValueStore\Api\KeyValueStore');
+        $this->store = new SortableDecorator($this->innerStore);
+    }
+
+    public function testGetDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('get')
+            ->with('key');
+
+        $this->store->get('key');
+    }
+
+    public function testGetOrFailDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('getOrFail')
+            ->with('key');
+
+        $this->store->getOrFail('key');
+    }
+
+    public function testGetMultipleDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('getMultiple')
+            ->with(array('key1', 'key2'));
+
+        $this->store->getMultiple(array('key1', 'key2'));
+    }
+
+    public function testGetMultipleOrFailDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('getMultipleOrFail')
+            ->with(array('key1', 'key2'));
+
+        $this->store->getMultipleOrFail(array('key1', 'key2'));
+    }
+
+    public function testSetDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('set')
+            ->with('key', 'value');
+
+        $this->store->set('key', 'value');
+    }
+
+    public function testRemoveDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('remove')
+            ->with('key');
+
+        $this->store->remove('key');
+    }
+
+    public function testExistsDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('exists')
+            ->with('key');
+
+        $this->store->exists('key');
+    }
+
+    public function testClearDelegate()
+    {
+        $this->innerStore->expects($this->once())
+            ->method('clear');
+
+        $this->store->clear();
+    }
+
+    public function testSortRegularStringKeys()
+    {
+        $this->store = new SortableDecorator(new ArrayStore());
+        $this->store->set('c', 1);
+        $this->store->set('a', 2);
+        $this->store->set('b', 3);
+
+        $this->store->sort();
+
+        $this->assertSame(array(
+            'a' => 2,
+            'b' => 3,
+            'c' => 1,
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortRegularIntegerKeys()
+    {
+        $this->store = new SortableDecorator(new ArrayStore());
+        $this->store->set(3, 'a');
+        $this->store->set(1, 'b');
+        $this->store->set(2, 'c');
+
+        $this->store->sort();
+
+        $this->assertSame(array(
+            1 => 'b',
+            2 => 'c',
+            3 => 'a',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortStringStringKeys()
+    {
+        $this->store = new SortableDecorator(new ArrayStore());
+        $this->store->set('c', 1);
+        $this->store->set('a', 2);
+        $this->store->set('b', 3);
+
+        $this->store->sort(SORT_STRING);
+
+        $this->assertSame(array(
+            'a' => 2,
+            'b' => 3,
+            'c' => 1,
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortNumericIntegerKeys()
+    {
+        $this->store = new SortableDecorator(new ArrayStore());
+        $this->store->set(3, 'a');
+        $this->store->set(1, 'b');
+        $this->store->set(2, 'c');
+
+        $this->store->sort(SORT_NUMERIC);
+
+        $this->assertSame(array(
+            1 => 'b',
+            2 => 'c',
+            3 => 'a',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortNaturalStringKeys()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('SORT_NATURAL not available');
+        }
+
+        $this->store = new SortableDecorator(new ArrayStore());
+
+        $this->store->set('10', 'c');
+        $this->store->set('1', 'g');
+        $this->store->set('100', 'a');
+        $this->store->set('9', 'b');
+        $this->store->set('7a', 'h');
+        $this->store->set('7b', 'd');
+        $this->store->set('_5', 'z');
+
+        $this->store->sort(SORT_NATURAL);
+
+        $this->assertSame(array(
+            '1' => 'g',
+            '7a' => 'h',
+            '7b' => 'd',
+            '9' => 'b',
+            '10' => 'c',
+            '100' => 'a',
+            '_5' => 'z',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+
+    public function testSortCaseInsensitiveStringKeys()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('SORT_FLAG_CASE not available');
+        }
+
+        $this->store = new SortableDecorator(new ArrayStore());
+
+        $this->store->set('_Ac', 'A');
+        $this->store->set('abc', 'F');
+        $this->store->set('_ab', 'G');
+        $this->store->set('ABB', 'E');
+        $this->store->set('Bce', 'C');
+        $this->store->set('bcd', 'D');
+        $this->store->set('bCf', 'E');
+
+        $this->store->sort(SORT_STRING | SORT_FLAG_CASE);
+
+        $this->assertSame(array(
+            '_ab' => 'G',
+            '_Ac' => 'A',
+            'ABB' => 'E',
+            'abc' => 'F',
+            'bcd' => 'D',
+            'Bce' => 'C',
+            'bCf' => 'E',
+        ), $this->store->getMultiple($this->store->keys()));
+    }
+}


### PR DESCRIPTION
As proposed in #8, I'm implementing a Sortable system.

Agenda:

- Rename `CachedStore` in `CachingDecorator` ✔
- Create a `SortableStore` interface for sortable stores ✔
- Create a `SortableDecorator` with a `sort()` method that use an array for an in-memory sort for others ✔
- Implement `sort()` for native sortable stores **WIP**

I'm currently wondering if I should create a `Decorator` namespace and a `Decorator` interface (as with this PR and the PR about countable, we will have 3 decorators). What do you think?