### PR TITLE
Remove old Assert namespaces

### DIFF
--- a/src/ArrayStore.php
+++ b/src/ArrayStore.php
@@ -13,7 +13,6 @@ namespace Webmozart\KeyValueStore;
 
 use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
-use Webmozart\KeyValueStore\Assert\Assert;
 use Webmozart\KeyValueStore\Util\KeyUtil;
 
 /**

--- a/src/PhpRedisStore.php
+++ b/src/PhpRedisStore.php
@@ -17,7 +17,6 @@ use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 use Webmozart\KeyValueStore\Api\ReadException;
 use Webmozart\KeyValueStore\Api\WriteException;
-use Webmozart\KeyValueStore\Assert\Assert;
 use Webmozart\KeyValueStore\Util\KeyUtil;
 use Webmozart\KeyValueStore\Util\Serializer;
 

--- a/src/PredisStore.php
+++ b/src/PredisStore.php
@@ -18,7 +18,6 @@ use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 use Webmozart\KeyValueStore\Api\ReadException;
 use Webmozart\KeyValueStore\Api\WriteException;
-use Webmozart\KeyValueStore\Assert\Assert;
 use Webmozart\KeyValueStore\Util\KeyUtil;
 use Webmozart\KeyValueStore\Util\Serializer;
 

--- a/src/RiakStore.php
+++ b/src/RiakStore.php
@@ -17,7 +17,6 @@ use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\Api\NoSuchKeyException;
 use Webmozart\KeyValueStore\Api\ReadException;
 use Webmozart\KeyValueStore\Api\WriteException;
-use Webmozart\KeyValueStore\Assert\Assert;
 use Webmozart\KeyValueStore\Util\KeyUtil;
 use Webmozart\KeyValueStore\Util\Serializer;
 


### PR DESCRIPTION
It seems you forgot to remove some namespaces during the commit https://github.com/webmozart/key-value-store/commit/877f9ab17716869f31cd800dc9d9cf157e836885.

This PR just remove them as they are not valid anymore.